### PR TITLE
Some more Gazebo improvements

### DIFF
--- a/distros/build-env/default.nix
+++ b/distros/build-env/default.nix
@@ -52,6 +52,15 @@ let
 
     postBuild = postBuild + ''
       "${buildPackages.perl}/bin/perl" "${./setup-hook-builder.pl}"
+
+      # Some ROS programs keep libraries and binaries in /opt.
+      if [ -d "$out/opt" ]; then
+        declare -A optMv=([lib]=lib [lib64]=lib [bin]=bin)
+        for dir in ''${!optMv[@]}; do
+          mkdir -p "$out/''${optMv["$dir"]}"
+          find -L "$out/opt" -mindepth 3 -maxdepth 3 -type f -executable -path "*/$dir/*" -not -name '.*' -exec ln -sf '{}' "$out/''${optMv["$dir"]}" \;
+        done
+      fi
     '' + optionalString wrapPrograms ''
       if [ -d "$out/bin" ]; then
         find -L "$out/bin" -executable -type f -xtype l -print0 | \

--- a/distros/ros2-overlay.nix
+++ b/distros/ros2-overlay.nix
@@ -144,6 +144,16 @@ rosSelf: rosSuper: with rosSelf.lib; {
       buildInputs;
   });
 
+  ros-gz-sim = rosSuper.ros-gz-sim.overrideAttrs ({ postPatch ? "", ... }: {
+    postPatch = postPatch + ''
+      # This launch file attempts to run the gz tool with a Ruby interpreter,
+      # but it is actually a regular executable.
+      substituteInPlace launch/gz_sim.launch.py.in \
+        --replace-warn 'ruby $(which gz) sim' 'gz sim' \
+        --replace-warn 'ruby $(which ign) gazebo' 'ign gazebo'
+    '';
+  });
+
   rosidl-generator-py = rosSuper.rosidl-generator-py.overrideAttrs ({ ... }: {
     setupHook = ./rosidl-generator-py-setup-hook.sh;
   });


### PR DESCRIPTION
This PR adds a couple of Gazebo improvements:

- `GZ_CONFIG_PATH` is included in the `buildEnv` wrapper for use outside of `nix-shell`
- `ros-gz-sim` has patched launch files to work around the Ruby issue